### PR TITLE
Translate new strings for 2.7, fix "Recents" translation

### DIFF
--- a/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
@@ -99,7 +99,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kürzlich verwendet"
+            "value" : "Neueste"
           }
         },
         "en" : {

--- a/PeakLocalisations/Localisation/Core/Formatting.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Formatting.xcstrings
@@ -1987,6 +1987,12 @@
     "Time.Milliseconds.Unit" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ms"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2027,6 +2033,33 @@
     "vo2Max %lf %@" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ %#@unit@"
+          },
+          "substitutions" : {
+            "unit" : {
+              "formatSpecifier" : "lf",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2086,6 +2119,33 @@
     "vo2Max.Attributed %lf %@" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[%2$@](measurement: 'value') ^[%#@unit@](measurement: 'unit’)"
+          },
+          "substitutions" : {
+            "unit" : {
+              "formatSpecifier" : "lf",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2145,6 +2205,33 @@
     "vo2Max.Unit %lf" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@unit@"
+          },
+          "substitutions" : {
+            "unit" : {
+              "formatSpecifier" : "lf",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "VO₂max"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Metrics.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Metrics.xcstrings
@@ -143,6 +143,12 @@
     "Blood Oxygen" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blutsauerstoff"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -254,6 +260,12 @@
     "Cardio Fitness" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cardiofitness"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -271,6 +283,12 @@
     "Cardio Recovery" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cardioerholung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -426,6 +444,12 @@
     "Heart Rate Variability" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herzfrequenzvariabilität"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -558,6 +582,12 @@
     "Resting Energy" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruheenergie"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -575,6 +605,12 @@
     "Resting Heart Rate" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruheherzfrequenz"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -639,6 +675,12 @@
     "Sleep" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlaf"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -656,6 +698,12 @@
     "Sleep Stage Asleep" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlafend"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -673,6 +721,12 @@
     "Sleep Stage Awake" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wach"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -690,6 +744,12 @@
     "Sleep Stage Core" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kernschlaf"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -707,6 +767,12 @@
     "Sleep Stage Deep" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiefschlaf"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -724,6 +790,12 @@
     "Sleep Stage In Bed" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Bett"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -741,6 +813,12 @@
     "Sleep Stage REM" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REM"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -874,6 +952,12 @@
     "Walking Heart Rate Average" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "∅-Herzfrequenz (Gehen)"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/AddMetrics.xcstrings
+++ b/PeakLocalisations/Localisation/Features/AddMetrics.xcstrings
@@ -188,6 +188,12 @@
     "Section.Vitals" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vitalzeichen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",


### PR DESCRIPTION
- Adds the new strings for 2.7 (mostly with the help of https://applelocalization.com/ again to match Apple's translations).
- Fix translation for "Recents". Resolves #27 