### PR TITLE
Initial stab at German translations

### DIFF
--- a/PeakLocalisations/Localisation/Blocks/AddBlock.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/AddBlock.xcstrings
@@ -5,6 +5,12 @@
       "comment" : "Feel free to translate this as “All” if there isn’t a good choice. The idea is this is a tab where you can make a custom widget, rather than choosing from the suggestions",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Individuell"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22,6 +28,12 @@
     "Tab.Suggestions" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschläge"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/AddGoal.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/AddGoal.xcstrings
@@ -73,6 +73,12 @@
     "Kind" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zieltyp"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Benchmark.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Benchmark.xcstrings
@@ -119,6 +119,12 @@
     "Title.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benchmarks"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
@@ -27,6 +27,12 @@
     "Block" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +50,12 @@
     "Blocks" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blöcke"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +73,12 @@
     "Edit Block" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block bearbeiten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -124,6 +142,12 @@
     "Kind.Chart.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafiken"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -187,6 +211,12 @@
     "Kind.Overview.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersichten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -250,6 +280,12 @@
     "Kind.Today" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -267,6 +303,12 @@
     "Kind.Today.Description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Statistiken für heute."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
@@ -4,6 +4,12 @@
     "GoalKind.Sleep8Hours" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8 Stunden Schlafen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "GoalKind.StartExercising" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit Training Beginnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "GoalKind.Walk10k" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10.000 Schritte Gehen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,6 +73,12 @@
     "GoalKind.Weight" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gewicht Zunehmen oder Abnehmen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72,6 +96,12 @@
     "Goals.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ziele"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -89,6 +119,12 @@
     "Stats.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiken & Zahlen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -106,6 +142,12 @@
     "StatsKind.DistanceRecents" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Schrittentfernungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +165,12 @@
     "StatsKind.StepsTotals" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schritte Diese Woche, Monat & Jahr"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -140,6 +188,12 @@
     "StatsKind.WorkoutOverview" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Übersicht Ihrer Trainings"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -157,6 +211,12 @@
     "Today.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -174,6 +234,12 @@
     "VisualizationKind.SleepTrends" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trends in Ihrem Schlaf"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -191,6 +257,12 @@
     "VisualizationKind.StepsBenchmark" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Schritte-Referenz Festlegen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -208,6 +280,12 @@
     "VisualizationKind.WeightChart" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafik Ihres Gewichts"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -225,6 +303,12 @@
     "Visualizations.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualisierungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/General.xcstrings
+++ b/PeakLocalisations/Localisation/Core/General.xcstrings
@@ -327,6 +327,12 @@
       "comment" : "This is used as the title of ellipsis … buttons that show additional options",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -413,6 +419,12 @@
     "Reorder" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Icons.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Icons.xcstrings
@@ -27,6 +27,12 @@
     "Icon.Arrows" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pfeile"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -136,6 +142,12 @@
     "Icon.Glass" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glas"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -153,6 +165,12 @@
     "Icon.Hearts" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herzen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Metrics.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Metrics.xcstrings
@@ -743,6 +743,12 @@
     "Section.Wellbeing" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wohlbefinden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Time.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Time.xcstrings
@@ -27,6 +27,24 @@
     "Last N Days" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Letzter Tag"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Letzte %lld Tage"
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -816,6 +834,12 @@
     "Window" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitfenster"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -834,6 +858,12 @@
       "comment" : "This is a setting used to make a graph show data based on the calendar, so a monthly chart would show data for say August",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kalenderbasiert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -852,6 +882,12 @@
       "comment" : "This is a setting used to make a graph show data based on rolling time periods, so a monthly chart would show data for the past 30 days",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rollierend"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Dashboard.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Dashboard.xcstrings
@@ -4,6 +4,12 @@
     "Edit Dashboard" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard Bearbeiten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "Grouping" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gruppierung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "Grouping.Freeform" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frei"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,6 +73,12 @@
     "Reorder Blocks" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blöcke Neu Anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72,6 +96,12 @@
     "Reorder Metrics" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metriken Neu Anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Home.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Home.xcstrings
@@ -4,6 +4,12 @@
     "Dashboard" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +50,12 @@
     "EmptyState.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fügen Sie einige Blöcke hinzu, um zu beginnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +73,12 @@
     "EmptyState.Body.Watch" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fügen Sie auf Ihrem Telefon einige Blöcke hinzu, um zu beginnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Setup.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Setup.xcstrings
@@ -4,10 +4,16 @@
     "Import.SuccessMessage" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihre aktuelle Aktivität ist bereit. Wir laden ältere Verläufe weiterhin im Hintergrund."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your recent activity is ready. We’ll keep loading older history in the background."
+            "value" : "Your recent activity is ready. We'll keep loading older history in the background."
           }
         },
         "es" : {
@@ -21,6 +27,12 @@
     "Import.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihr Dashboard Wird Vorbereitet"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "Restore.GetStarted" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loslegen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
+++ b/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
@@ -4,6 +4,12 @@
     "Dashboard.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt mit mehreren Widget-Größen, Gruppierungsmodi und schneller Filterung!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "Dashboard.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brandneues Dashboard!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -62,6 +74,12 @@
     "LiquidGlass.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peak wurde für iOS 26 und Liquid Glass neu gestaltet"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -80,6 +98,12 @@
       "comment" : "This is a play on the phrase “A Fresh Coat of Paint”. If something similar doesn’t exist, feel free to use “Liquid Glass Design” or similar",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Frische Schicht Glas"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -97,6 +121,12 @@
     "Speed.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihre Daten laden jetzt schneller als je zuvor"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -115,10 +145,16 @@
       "comment" : "This is just a phrase about speed. If something similar doesn’t exist, feel free to use “Faster Than Ever Before” or similar",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blinzeln und Du Verpasst Es"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blink and You’ll Miss It"
+            "value" : "Blink and You'll Miss It"
           }
         },
         "es" : {
@@ -142,7 +178,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "What’s New in Peak 5"
+            "value" : "What's New in Peak 5"
           }
         },
         "es" : {


### PR DESCRIPTION
Turns out iOS is strange with translations. If a language doesn't have a value for a key, rather than falling back to another language in your stack or the base localization, it shows the raw key. This wasn't great especially for the what's new screen which people will see on launch, so I've temporarily used Claude to generate some German translations