### PR TITLE
[5] Add German translations

### DIFF
--- a/PeakLocalisations/Localisation/Blocks/AddBlock.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/AddBlock.xcstrings
@@ -5,6 +5,12 @@
       "comment" : "Feel free to translate this as “All” if there isn’t a good choice. The idea is this is a tab where you can make a custom widget, rather than choosing from the suggestions",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Individuell"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22,6 +28,12 @@
     "Tab.Suggestions" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschläge"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/AddGoal.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/AddGoal.xcstrings
@@ -73,6 +73,12 @@
     "Kind" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Art des Ziels"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Benchmark.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Benchmark.xcstrings
@@ -119,6 +119,12 @@
     "Title.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benchmarks"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Blocks.xcstrings
@@ -27,6 +27,12 @@
     "Block" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +50,12 @@
     "Blocks" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blöcke"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +73,12 @@
     "Edit Block" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block bearbeiten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -124,6 +142,12 @@
     "Kind.Chart.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafiken"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -187,6 +211,12 @@
     "Kind.Overview.Plural" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersichten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -250,6 +280,12 @@
     "Kind.Today" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -267,6 +303,12 @@
     "Kind.Today.Description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine heutigen Statistiken."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
@@ -36,7 +36,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Start Workout Out"
+            "value" : "Start Working Out"
           }
         },
         "es" : {

--- a/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Recommendations.xcstrings
@@ -4,6 +4,12 @@
     "GoalKind.Sleep8Hours" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8 Stunden Schlafen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "GoalKind.StartExercising" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit dem Training beginnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "GoalKind.Walk10k" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10.000 Schritte Gehen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,6 +73,12 @@
     "GoalKind.Weight" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ab- oder zunehmen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72,6 +96,12 @@
     "Goals.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ziele"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -89,6 +119,12 @@
     "Stats.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zahlen & Statistiken"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -106,6 +142,12 @@
     "StatsKind.DistanceRecents" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Schritt-Entfernungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +165,12 @@
     "StatsKind.StepsTotals" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schritte in der Woche, im Monat & im Jahr "
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -140,6 +188,12 @@
     "StatsKind.WorkoutOverview" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Übersicht über deine Trainings"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -157,6 +211,12 @@
     "Today.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -174,6 +234,12 @@
     "VisualizationKind.SleepTrends" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trends in deinem Schlaf"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -191,6 +257,12 @@
     "VisualizationKind.StepsBenchmark" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setze einen Schritte-Benchmark"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -208,6 +280,12 @@
     "VisualizationKind.WeightChart" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualisiere dein Gewicht"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -225,6 +303,12 @@
     "Visualizations.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualisierungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/General.xcstrings
+++ b/PeakLocalisations/Localisation/Core/General.xcstrings
@@ -327,6 +327,12 @@
       "comment" : "This is used as the title of ellipsis … buttons that show additional options",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -413,6 +419,12 @@
     "Reorder" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu Anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Icons.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Icons.xcstrings
@@ -27,6 +27,12 @@
     "Icon.Arrows" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pfeile"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -136,6 +142,12 @@
     "Icon.Glass" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glas"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -153,6 +165,12 @@
     "Icon.Hearts" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herzen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Metrics.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Metrics.xcstrings
@@ -743,6 +743,12 @@
     "Section.Wellbeing" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wohlbefinden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Time.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Time.xcstrings
@@ -27,6 +27,24 @@
     "Last N Days" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Letzter Tag"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Letzte %lld Tage"
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -816,6 +834,12 @@
     "Window" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitfenster"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -834,6 +858,12 @@
       "comment" : "This is a setting used to make a graph show data based on the calendar, so a monthly chart would show data for say August",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kalendarisch"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -852,6 +882,12 @@
       "comment" : "This is a setting used to make a graph show data based on rolling time periods, so a monthly chart would show data for the past 30 days",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rollierend"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Dashboard.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Dashboard.xcstrings
@@ -4,6 +4,12 @@
     "Edit Dashboard" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard bearbeiten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "Grouping" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gruppierung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "Grouping.Freeform" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frei"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,6 +73,12 @@
     "Reorder Blocks" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blöcke neu anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72,6 +96,12 @@
     "Reorder Metrics" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metriken neu anordnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Home.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Home.xcstrings
@@ -4,6 +4,12 @@
     "Dashboard" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +50,12 @@
     "EmptyState.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge Blöcke hinzu, um loszulegen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +73,12 @@
     "EmptyState.Body.Watch" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge Blöcke auf deinem iPhone hinzu, um loszulegen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Setup.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Setup.xcstrings
@@ -4,6 +4,12 @@
     "Import.SuccessMessage" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine kürzlichen Aktivitäten stehen bereit. Die restlichen Aktivitäten werden im Hintergrund geladen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "Import.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein Dashboard wird vorbereitet"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38,6 +50,12 @@
     "Restore.GetStarted" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt loslegen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
+++ b/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
@@ -4,6 +4,12 @@
     "Dashboard.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt mit mehreren Widget-Grössen, Gruppierungsmodi, und Filter-Schnellzugriffen!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21,6 +27,12 @@
     "Dashboard.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brandneues Dashboard!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -62,6 +74,12 @@
     "LiquidGlass.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peak wurde für iOS 26 und Liquid Glass neu gestaltet"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -80,6 +98,12 @@
       "comment" : "This is a play on the phrase “A Fresh Coat of Paint”. If something similar doesn’t exist, feel free to use “Liquid Glass Design” or similar",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frisch poliertes Glas"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -97,6 +121,12 @@
     "Speed.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Daten laden jetzt schneller als je zuvor"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -115,6 +145,12 @@
       "comment" : "This is just a phrase about speed. If something similar doesn’t exist, feel free to use “Faster Than Ever Before” or similar",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blitzschnell"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",


### PR DESCRIPTION
@HarshilShah I saw #48, but decided to start on `main`, since I don't see which strings are new otherwise. For literal stuff, Claude did a pretty good job - most of my translations are the same, with the exception for some terminology that is already used differently. For more complex stuff, like the What's New strings, it still translated them pretty literally, which would not have a special meaning in German. Though my strings are a bit more "on target" than a literal translation, I'm also not the best at finding matching sayings in such cases.