### PR TITLE
Add German translations

### DIFF
--- a/PeakLocalisations/Localisation/App Store/Screenshots.xcstrings
+++ b/PeakLocalisations/Localisation/App Store/Screenshots.xcstrings
@@ -29,8 +29,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Erreiche deine Ziele"
+            "state" : "translated",
+            "value" : "Ziele und Vorsätze die du auch erreichts"
           }
         },
         "en" : {
@@ -52,8 +52,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gestern zusammengefasst"
+            "state" : "translated",
+            "value" : "Fasse deine Fitness-Reise zusammen"
           }
         },
         "en" : {
@@ -74,6 +74,12 @@
       "comment" : "This sentence continues from the visualizations pitch",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "…Oder tauche in die Zahlen ein"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -92,6 +98,12 @@
       "comment" : "This sentence continues into the stats pitch",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualisiere deinen Fortschritt…"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Blocks/Totals.xcstrings
+++ b/PeakLocalisations/Localisation/Blocks/Totals.xcstrings
@@ -27,6 +27,12 @@
     "Periods.Comparison" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vergleich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +50,12 @@
     "Periods.MonthYearAllTime" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monat, Jahr & Gesamt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +73,12 @@
     "Periods.Ongoing" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortlaufend"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -78,6 +96,12 @@
     "Periods.WeekMonthYear" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Woche, Monat & Jahr"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Themes.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Themes.xcstrings
@@ -1040,6 +1040,12 @@
     "Nature.Lagoon" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lagune"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Core/Time.xcstrings
+++ b/PeakLocalisations/Localisation/Core/Time.xcstrings
@@ -132,6 +132,12 @@
     "Periods" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeiträume"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -149,6 +155,12 @@
     "Unit.AllTime" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Preferences.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Preferences.xcstrings
@@ -52,6 +52,12 @@
     "About the Developer.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peak wird von Harshil Shah in Mumbai, Indien, gestaltet & entwickelt."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69,6 +75,12 @@
     "AboutTheDeveloper.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über den Entwickler"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1195,6 +1207,12 @@
     "Website" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webseite"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
+++ b/PeakLocalisations/Localisation/Features/WhatsNew.xcstrings
@@ -50,6 +50,12 @@
     "Icons.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt verfügbar in Rot, Orange, Grün, Blau, Violett, Silber und Gold!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67,6 +73,12 @@
     "Icons.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue App Icons"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -226,6 +238,12 @@
     "Totals.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Summen Block zeigt dir deine Gesamt-Statistiken"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -243,6 +261,12 @@
     "Totals.Title " : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamt-Summen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -260,6 +284,12 @@
     "Trends.Body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurzfristige, mittelfristige und langfristige Trends zusammengefasst"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -277,6 +307,12 @@
     "Trends.Title" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehrere Trends"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PeakLocalisations/Localisation/Features/Widget.xcstrings
+++ b/PeakLocalisations/Localisation/Features/Widget.xcstrings
@@ -5,13 +5,33 @@
 
     },
     "%@" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        }
+      }
     },
     "%@ " : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        }
+      }
     },
     "%@ %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -22,6 +42,12 @@
     },
     "%@ %@ %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ %3$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -32,6 +58,12 @@
     },
     "%@ %@: %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@: %3$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -74,6 +106,12 @@
     },
     "%@: %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -84,6 +122,12 @@
     },
     "%@%@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -245,28 +289,84 @@
       }
     },
     "DoNotLocalize.configKey" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.configKey"
+          }
+        }
+      }
     },
     "DoNotLocalize.dayComponents" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.dayComponents"
+          }
+        }
+      }
     },
     "DoNotLocalize.DeepLink" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.DeepLink"
+          }
+        }
+      }
     },
     "DoNotLocalize.HistoryWidgetDayPicker" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.HistoryWidgetDayPicker"
+          }
+        }
+      }
     },
     "DoNotLocalize.OpenDeepLink" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.OpenDeepLink"
+          }
+        }
+      }
     },
     "DoNotLocalize.period" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.period"
+          }
+        }
+      }
     },
     "DoNotLocalize.refresh" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.refresh"
+          }
+        }
+      }
     },
     "DoNotLocalize.TrendsChartPeriodPicker" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DoNotLocalize.TrendsChartPeriodPicker"
+          }
+        }
+      }
     },
     "Goal" : {
       "localizations" : {
@@ -663,7 +763,14 @@
       }
     },
     "Periods" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeiträume"
+          }
+        }
+      }
     },
     "RecentsWidget.Description" : {
       "localizations" : {


### PR DESCRIPTION
A few notes regarding the `Widget` translations:

- There seems to be an empty string?
- The `DoNotLocalize.*` translations:
  - I'm wondering where they come from? As in whether there would be ways to prevent them by using normal `String` instead of `LocalizedStringKey` (or any of its localized friends)? Otherwise you could still mark them as "Don't Translate":
    <img width="330" height="105" alt="image" src="https://github.com/user-attachments/assets/855e27d6-bf21-4f82-bd4e-d620d56f9ae7" />
  - I've still copied them over to get (close to) a checkmark.
- All the placeholder only translations could do with some comments what they're doing and whether it would actually be relevant to re-order them in some translation.